### PR TITLE
fix: block user after 5 failed security answer verification attempts

### DIFF
--- a/listener/security/security.js
+++ b/listener/security/security.js
@@ -53,6 +53,11 @@ exports.verifySecurityAnswer = async (context, requestKey, requestObject) => {
     catch (error) {
         logger.log('error', 'Wrong security answer (from decryption failure); increasing security answer attempts', error);
         await sqlInterface.increaseSecurityAnswerAttempt(requestObject);
+        // the attempts are now increased to 5
+        if (user.Attempt === 4) {
+            logger.log('verbose', `Blocked user ${requestObject?.UserID} after reaching 5 invalid security answer attempts`);
+            await sqlInterface.setTimeoutSecurityAnswer(requestObject, requestObject.Timestamp);
+        }
         return new OpalSecurityResponseSuccess(answerNotVerified, requestKey, requestObject);
     }
 
@@ -85,8 +90,7 @@ async function handleTooManyAttempts(requestKey, requestObject, user) {
     }
     // If 5 failed attempts have been made, lock the user out for 5 minutes
     else if (user.Attempt === 5) {
-        logger.log('verbose', `Blocking user after reaching 5 security answer attempts for username ${requestObject?.UserID}`);
-        if (user.TimeoutTimestamp == null) await sqlInterface.setTimeoutSecurityAnswer(requestObject, requestObject.Timestamp);
+        logger.log('verbose', `User ${requestObject?.UserID} has 5 security answer attempts`);
         throw new OpalSecurityResponseError(CODE.TOO_MANY_ATTEMPTS, "Attempted and failed security answer 5 times", requestKey, requestObject);
     }
 }

--- a/listener/security/security.js
+++ b/listener/security/security.js
@@ -89,8 +89,8 @@ async function handleTooManyAttempts(requestKey, requestObject, user) {
         await sqlInterface.resetSecurityAnswerAttempt(requestObject);
     }
     // If 5 failed attempts have been made, lock the user out for 5 minutes
-    else if (user.Attempt === 5) {
-        logger.log('verbose', `User ${requestObject?.UserID} has 5 security answer attempts`);
+    else if (user.Attempt >= 5) {
+        logger.log('verbose', `User ${requestObject?.UserID} has 5 invalid security answer attempts`);
         throw new OpalSecurityResponseError(CODE.TOO_MANY_ATTEMPTS, "Attempted and failed security answer 5 times", requestKey, requestObject);
     }
 }


### PR DESCRIPTION
Set the timeout timestamp after 5 failed security answer verification attempts instead of on the 6th request.
The difference is that the timeout timestamp is set after 5 tries instead of when the 6th attempt is processed.

Related to #422 