### PR TITLE
fix: increase log level to verbose for request processing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -69,3 +69,10 @@ SOURCE_SYSTEM_SUPPORTS_CHECKIN=0
 SOURCE_SYSTEM_CHECKIN_URL=
 # Opal Backend Checkin Endpoint: http[s]://{BACKEND_HOST_INTERNAL}/api/patients/legacy/appointment/checkin/
 OPAL_CHECKIN_URL=http://host.docker.internal:8000/api/patients/legacy/appointment/checkin/
+
+# Logging customizations
+# DISABLE_LOGGING=true
+# by default log level is debug in development and info in production
+# explicitly use another log level
+# see: https://github.com/winstonjs/winston?tab=readme-ov-file#logging-levels
+# LOG_LEVEL=verbose

--- a/legacy-registration/api/request/request.js
+++ b/legacy-registration/api/request/request.js
@@ -118,7 +118,7 @@ class opalRequest {
 			headers: headers,
 			data: registerData,
 		};
-		logger.log('info', 'Calling API to register patient in the backend', url)
+		logger.log('verbose', 'Calling API to register patient in the backend', url)
 		const response = await this.axiosApi(requestParams);
 		return response.data;
 	}
@@ -165,7 +165,7 @@ class opalRequest {
 			url: url,
 			headers: headers,
 		};
-		logger.log('info', 'Calling API to determine if the user is an existing caregiver or not', url);
+		logger.log('verbose', 'Calling API to determine if the user is an existing caregiver or not', url);
 		const response = await this.axiosApi(requestParams);
 		if (!response) {
 			logger.log('error', 'API response error', response);

--- a/listener/api/apiPatientUpdate.js
+++ b/listener/api/apiPatientUpdate.js
@@ -55,7 +55,7 @@ exports.refresh = async function(requestObject) {
 
     // If there's a TargetPatientID, use it, otherwise get data for self
     let patientSerNum = requestObject.TargetPatientID ? requestObject.TargetPatientID : await sqlInterface.getSelfPatientSerNum(UserId);
-    logger.log('info', `Identified request target as PatientSerNum = ${patientSerNum}`);
+    logger.log('verbose', `Identified request target as PatientSerNum = ${patientSerNum}`);
 
     if (!fields) throw {Response:'error', Reason:"Undefined 'Fields' in Refresh request"};
     if (!Array.isArray(fields)) fields = [fields];
@@ -103,7 +103,7 @@ exports.getStudyQuestionnaires = function(requestObject) {
 // };
 
 exports.logActivity = function (requestObject) {
-    logger.log('info', 'User Activity', {
+    logger.log('verbose', 'User Activity', {
         deviceID:requestObject.DeviceId,
         userID:requestObject.UserID,
         request:requestObject.Request,

--- a/listener/api/main.js
+++ b/listener/api/main.js
@@ -39,7 +39,7 @@ function requestFormatter(context, {key,request}) {
 			return processApiRequest.processRequest(opalReq).then((data)=>
 			{
 				logger.log('debug', 'Successfully processed request: ', data);
-				logger.log('info', 'Successfully processed request');
+				logger.log('verbose', 'Successfully processed request');
 				return (new OpalResponseSuccess(data, opalReq)).toLegacy();
 			}).catch((err)=>{
 				logger.log('error', 'Error processing request', err);

--- a/listener/api/processApiRequest.js
+++ b/listener/api/processApiRequest.js
@@ -89,7 +89,7 @@ exports.processRequest=function(requestObject) {
     if (omitParametersFromLogs.hasOwnProperty(type) && omitParametersFromLogs[type](requestObject.params)) parametersString = 'OMITTED FROM LOGS';
 
     // Old requests
-    logger.log('info', `Processing request of type: '${type}', with params = ${parametersString}${target ? ', TargetPatientID = '+target : ''}`);
+    logger.log('verbose', `Processing request of type: '${type}', with params = ${parametersString}${target ? ', TargetPatientID = '+target : ''}`);
     if (LEGACYAPI.hasOwnProperty(type)) {
         return LEGACYAPI[type](requestObject.toLegacy());
     // New request format

--- a/listener/api/request/request-validator.js
+++ b/listener/api/request/request-validator.js
@@ -125,16 +125,16 @@ class RequestValidator {
 		}
 
 		// Check user's permissions by calling Django's API endpoint (e.g., /check-permissions/)
-		logger.log('info', `Checking permissions for ${logDetails}, via API request to the backend`);
+		logger.log('verbose', `Checking permissions for ${logDetails}, via API request to the backend`);
 		let apiResponse;
 		try {
 			apiResponse = await ApiRequest.sendRequestToApi(request.meta.UserID, {
 				url: `/api/patients/legacy/${request.meta.TargetPatientID}/check-permissions/`,
 				headers: {},
 			});
-			logger.log('info', `Permissions response received with status = ${apiResponse.status} for ${logDetails}`, apiResponse.data);
+			logger.log('verbose', `Permissions response received with status = ${apiResponse.status} for ${logDetails}`, apiResponse.data);
 			if (apiResponse.status !== 200) throw apiResponse;
-			else logger.log('info', `Permission granted: response code 200, for ${logDetails}`);
+			else logger.log('verbose', `Permission granted: response code 200, for ${logDetails}`);
 		}
 		catch(axiosError) {
 			logger.log('error', 'Error during permissions validation', axiosError);

--- a/listener/api/sqlInterface.js
+++ b/listener/api/sqlInterface.js
@@ -283,7 +283,7 @@ exports.updateReadStatus = function(userId, parameters)
             [table, userId, table, serNum, parameters.Id],
         ).then(async () => {
             if (notificationType) {
-                logger.log('info', `Implicitly marking ${notificationType} notification as read.`);
+                logger.log('verbose', `Implicitly marking ${notificationType} notification as read.`);
                 await exports.runSqlQuery(
                     queries.implicitlyReadNotification(),
                     [userId, `"${userId}"`, parameters.Id, parameters.TargetPatientID, notificationType],

--- a/listener/cron/clearRequests.js
+++ b/listener/cron/clearRequests.js
@@ -36,7 +36,7 @@ function clearRequests(){
         const requestData = snapshot.val();
         for (const requestKey in requestData) {
             if(requestData[requestKey].hasOwnProperty('Timestamp')&&now-requestData[requestKey].Timestamp>300000) {
-                logger.log('info', 'Deleting leftover request on firebase', {
+                logger.log('verbose', 'Deleting leftover request on firebase', {
                     requestKey: requestKey
                 });
                 ref.child('requests/' + requestKey).set(null);

--- a/listener/cron/clearResponses.js
+++ b/listener/cron/clearResponses.js
@@ -38,7 +38,7 @@ function clearResponses() {
             {
                 if(usersData[user][requestKey].hasOwnProperty('Timestamp')&&now-usersData[user][requestKey].Timestamp>300000)
                 {
-                    logger.log('info','Deleting leftover response on firebase', {
+                    logger.log('verbose','Deleting leftover response on firebase', {
                         request: requestKey
                     });
                     ref.child('users/'+user+'/'+requestKey).set(null);

--- a/listener/legacy-server.js
+++ b/listener/legacy-server.js
@@ -52,7 +52,7 @@ function listenForRequest(requestType){
     ref.child(requestType).on('child_added',
         function(snapshot){
             logger.log('debug', 'Received request from Firebase: ', snapshot.val());
-            logger.log('info', 'Received request from Firebase: ', snapshot.val().Request);
+            logger.log('verbose', 'Received request from Firebase: ', snapshot.val().Request);
             handleRequest(requestType,snapshot);
         },
         function(error){
@@ -105,7 +105,7 @@ function logResponse(response){
 			(response.Headers.RequestObject.Request === 'Refresh' ? ": " + response.Headers.RequestObject.Parameters.Fields.join(' ') : ""),
 			requestKey: response.Headers.RequestKey
 		});
-        logger.log('info', "Completed response", response.Headers.RequestObject.Request);
+        logger.log('verbose', "Completed response", response.Headers.RequestObject.Request);
 	}
 }
 
@@ -117,7 +117,7 @@ function logResponse(response){
  */
 function processRequest(context, headers){
 
-    logger.log('info', 'Processing request');
+    logger.log('verbose', 'Processing request');
 
     const r = q.defer();
     const requestKey = headers.key;

--- a/listener/logs/logger.js
+++ b/listener/logs/logger.js
@@ -7,7 +7,10 @@
 const {createLogger, format, transports} = require('winston');
 
 // Choose log level according to environment.
-const LoggerLevel = process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+const defaultLoggerLevel = process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+
+// allow the log level to be specifically set via env variable
+const loggerLevel = process.env.LOG_LEVEL ?? defaultLoggerLevel;
 
 // Set custom format for login.
 const opalLogFormat = format.printf((info) => {
@@ -30,7 +33,7 @@ const WinstonLogger = createLogger({
     // Silent logger when running unit tests.
     silent: process.env.DISABLED_LOGGING === 'true',
     // Set level log level
-    level: LoggerLevel,
+    level: loggerLevel,
     // Set log format output in the log file
     format: format.combine(
         format.timestamp({format: 'YYYY-MM-DD HH:mm:ss'}),
@@ -49,12 +52,12 @@ const WinstonLogger = createLogger({
     ]
 });
 
-// Wrappe logger to allow 3rd arguments to be of any type.
+// Wrap logger to allow 3rd arguments to be of any type.
 const logWrapper = (level, message, data) => {
     WinstonLogger.log(level, message, {data: data});
 }
 
-WinstonLogger.log('info', `Initialized Winston with level: ${LoggerLevel}`);
+WinstonLogger.log('info', `Initialized Winston with level: ${loggerLevel}`);
 
 module.exports = {
     ...WinstonLogger,

--- a/listener/logs/logger.js
+++ b/listener/logs/logger.js
@@ -42,7 +42,7 @@ const WinstonLogger = createLogger({
     ),
     transports: [
         new transports.File({ filename:'./listener/logs/error.log', level: 'error'}),
-        new transports.Console({level: 'debug'})
+        new transports.Console()
     ],
     exceptionHandlers: [
         // Log uncaught exceptions to a different file and console.

--- a/listener/logs/logger.js
+++ b/listener/logs/logger.js
@@ -31,7 +31,7 @@ const formatErrorData = (data) => {
 // Initialize winston logger
 const WinstonLogger = createLogger({
     // Silent logger when running unit tests.
-    silent: process.env.DISABLED_LOGGING === 'true',
+    silent: process.env.DISABLE_LOGGING === 'true',
     // Set level log level
     level: loggerLevel,
     // Set log format output in the log file
@@ -41,14 +41,13 @@ const WinstonLogger = createLogger({
         opalLogFormat
     ),
     transports: [
-        // Log level info and above in the log file.
-        new transports.File({ filename:'./listener/logs/opal-info.log', level: 'info'}),
+        new transports.File({ filename:'./listener/logs/error.log', level: 'error'}),
         new transports.Console({level: 'debug'})
     ],
     exceptionHandlers: [
         // Log uncaught exceptions to a different file and console.
-        new transports.File({ filename: './listener/logs/opal-uncaughtExceptions.log'}),
-        new transports.Console({level: 'debug'})
+        new transports.File({ filename: './listener/logs/exceptions.log'}),
+        new transports.Console()
     ]
 });
 

--- a/listener/questionnaires/questionnaireDjango.js
+++ b/listener/questionnaires/questionnaireDjango.js
@@ -26,7 +26,7 @@ class QuestionnaireDjango {
             },
             UserID: userId,
         };
-        logger.log('info', "API: Calling backend to get the caregiver's list of relationships");
+        logger.log('verbose', "API: Calling backend to get the caregiver's list of relationships");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response.data) return response.data;
         else throw new Error('Failed to get caregiver relationships from the backend');

--- a/listener/questionnaires/questionnaireOpalDB.js
+++ b/listener/questionnaires/questionnaireOpalDB.js
@@ -234,7 +234,7 @@ async function questionnaireUpdateStatus(requestObject) {
     // Note that the notification will be marked as read for the self-user and all caregivers.
     const newStatusInt = parseInt(requestObject.Parameters.new_status);
     if (newStatusInt === questionnaireConfig.IN_PROGRESS_QUESTIONNAIRE_STATUS) {
-        logger.log('info', "Implicitly marking the questionnaire's notification as read.");
+        logger.log('verbose', "Implicitly marking the questionnaire's notification as read.");
 
         const questionnaire = await OpalSQLQueryRunner.run(
             opalQueries.getOpalDBQuestionnaire(),
@@ -252,7 +252,7 @@ async function questionnaireUpdateStatus(requestObject) {
             UserID: requestObject.UserID,
         };
 
-        logger.log('info', "API: Calling backend to get the user's list of caregivers.");
+        logger.log('verbose', "API: Calling backend to get the user's list of caregivers.");
         const response = await ApiRequest.makeRequest(requestParams);
         // Silently exit if lister cannot fetch the user's list of caregivers
         if (!response?.data) {
@@ -338,7 +338,7 @@ async function getQuestionnaireLanguage(requestObject) {
  * @throws Throws an error if caregiver does not have permissions to answer the questionnaire.
  */
 async function checkCaregiverPermissions(userId, patientSerNum) {
-    logger.log('info', "Checking if caregiver can answer questionnaire.");
+    logger.log('verbose', "Checking if caregiver can answer questionnaire.");
 
     let canAnswerPatientQuestionnaires = await QuestionnaireDjango.caregiverCanAnswerQuestionnaire(
         userId,

--- a/listener/security/security.js
+++ b/listener/security/security.js
@@ -36,7 +36,7 @@ exports.verifySecurityAnswer = async (context, requestKey, requestObject) => {
     // Special case used to set the request's UserID in the case of password reset requests
     await ensureUserIdAvailable(requestObject);
 
-    logger.log('info', `Verifying security answer for username ${requestObject?.UserID}`);
+    logger.log('verbose', `Verifying security answer for username ${requestObject?.UserID}`);
 
     // Get security info needed to verify the answer, including the cached answer from PatientDeviceIdentifier.
     let user = await getUserPatientSecurityInfo(requestKey, requestObject);
@@ -127,7 +127,7 @@ exports.resetPassword = async function(context, requestKey, requestObject) {
     // Special case used to set the request's UserID in the case of password reset requests
     await ensureUserIdAvailable(requestObject);
 
-    logger.log('info', `Running function resetPassword for username = ${requestObject.UserID}`);
+    logger.log('verbose', `Running function resetPassword for username = ${requestObject.UserID}`);
 
     // Get security info needed to set a new password
     let user = await getUserPatientSecurityInfo(requestKey, requestObject);

--- a/listener/security/securityDjango.js
+++ b/listener/security/securityDjango.js
@@ -27,7 +27,7 @@ class SecurityDjango {
                 },
             },
         };
-        logger.log('info', "API: Calling backend to get random security question and answer for the user");
+        logger.log('verbose', "API: Calling backend to get random security question and answer for the user");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response?.data) return response.data;
         else {
@@ -52,7 +52,7 @@ class SecurityDjango {
                 },
             },
         };
-        logger.log('info', "API: Calling backend to get all the active security questions");
+        logger.log('verbose', "API: Calling backend to get all the active security questions");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response?.data) return response.data;
         else {
@@ -79,7 +79,7 @@ class SecurityDjango {
                 },
             },
         };
-        logger.log('info', "API: Calling backend to get a specific active security question");
+        logger.log('verbose', "API: Calling backend to get a specific active security question");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response?.data) return response.data;
         else {
@@ -105,7 +105,7 @@ class SecurityDjango {
                 },
             },
         };
-        logger.log('info', "API: Calling backend to get a list of security questions for the user");
+        logger.log('verbose', "API: Calling backend to get a list of security questions for the user");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response?.data) return response.data;
         else {
@@ -133,7 +133,7 @@ class SecurityDjango {
                 },
             },
         };
-        logger.log('info', "API: Calling backend to get a specific security question for the user");
+        logger.log('verbose', "API: Calling backend to get a specific security question for the user");
         const response = await ApiRequest.makeRequest(requestParams);
         if (response?.data) return response.data;
         else {
@@ -166,7 +166,7 @@ class SecurityDjango {
             };
             ApiRequest.makeRequest(requestParams);
         });
-        logger.log('info', "API: Calling backend to update security answers for the questions user provided");
+        logger.log('verbose', "API: Calling backend to update security answers for the questions user provided");
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "docs": "run-script-os",
     "docs:nix": "./node_modules/.bin/jsdoc src README.md -c docs/jsdoc.config.json",
     "docs:windows": ".\\node_modules\\.bin\\jsdoc src README.md -c docs/jsdoc.config.json",
-    "test": "cross-env DISABLED_LOGGING=true mocha './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'",
+    "test": "cross-env DISABLE_LOGGING=true mocha './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'",
     "coverage": "nyc mocha './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'",
     "start": "node src/server.js",
     "watch": "nodemon src/server.js",

--- a/src/core/request-handler.js
+++ b/src/core/request-handler.js
@@ -35,7 +35,7 @@ class RequestHandler {
      * @param {string} requestType The Firebase branch on which to listen, representing a type of request.
      */
     listenForRequests(requestType) {
-        legacyLogger.log('debug', `API: Starting request listener on ${requestType}`);
+        legacyLogger.log('info', `API: Starting request listener on ${requestType}`);
         this.#databaseRef.child(requestType).off();
         this.#databaseRef.child(requestType).on('child_added', snapshot => this.processRequest(requestType, snapshot));
     }

--- a/src/registration/registration.js
+++ b/src/registration/registration.js
@@ -37,13 +37,13 @@ class Registration {
 
         // On cache miss, call the API to get encryption info
         if (!await regCache.get(instanceSalt) || !await regCache.get(instanceSecret)) {
-            legacyLogger.log('info', 'Registration encryption data cache miss or TTL expired; fetching new data');
+            legacyLogger.log('verbose', 'Registration encryption data cache miss or TTL expired; fetching new data');
             const response = await ApiRequest.makeRequest(requestParams);
             return this.secretAndSaltFromResponse(response);
         }
 
         // Otherwise, on cache hit, retrieve encryption values from memory
-        legacyLogger.log('info', 'Loading registration encryption data from cache and resetting TTL');
+        legacyLogger.log('verbose', 'Loading registration encryption data from cache and resetting TTL');
         await regCache.set(
             instanceSalt,
             await regCache.get(instanceSalt),
@@ -105,7 +105,7 @@ class Registration {
         encryptionInfo.salt = salt;
 
         // Cache encryption info for the first time (once we know which salt was successful) or reset TTL
-        legacyLogger.log('info', 'Caching registration encryption data or resetting TTL');
+        legacyLogger.log('verbose', 'Caching registration encryption data or resetting TTL');
         await regCache.set(
             getInstanceSalt(context),
             encryptionInfo.salt,


### PR DESCRIPTION
Make log level configurable via `LOG_LEVEL` env variable.
Also increase the log level for most request logging from `info` to `verbose`.

Log levels: https://www.npmjs.com/package/winston#logging-levels

Fixes #423 