### PR TITLE
ci: add jobs to run mocha and calculate coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,63 @@ jobs:
   run-reuse-workflow:
     uses: opalmedapps/.github/.github/workflows/reuse.yaml@main
 
+  test-mocha:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install dependencies
+        run: npm ci
+      - name: Print mocha version
+        run: npx mocha --version
+
+      # Run tests
+      - name: Run mocha
+        run: npx mocha --reporter json --reporter-option output=mocha-report.json './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
+
+      # Format the output for GitHub
+      - name: Report test results for GitHub
+        uses: dorny/test-reporter@v2.1.0
+        # Run this step even if the previous step failed
+        if: ${{ !cancelled() }}
+        with:
+          # Name of the check run which will be created
+          name: Mocha Tests
+          path: mocha-report.json
+          reporter: mocha-json
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install dependencies
+        run: npm ci
+
+      # Run coverage evaluation
+      - name: Run nyc / cobertura
+        run: |
+          npx nyc --all --reporter cobertura mocha './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
+          npx nyc report
+
+      # Format the output for GitHub
+      - name: Report coverage results
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/cobertura-coverage.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          output: both
+      - name: Display the report as a job summary
+        run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+
   build-image:
-    needs:
-      - lint
+    needs: [lint, test-mocha]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
         with:
           filename: coverage/cobertura-coverage.xml
           badge: true
-          fail_below_min: true
+          fail_below_min: false
           format: markdown
           output: both
       - name: Display the report as a job summary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,12 +52,11 @@ jobs:
         run: npx mocha --reporter json --reporter-option output=mocha-report.json './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
 
       # Format the output for GitHub
-      - name: Report test results for GitHub
+      - name: Report test results
         uses: dorny/test-reporter@v2.1.0
         # Run this step even if the previous step failed
         if: ${{ !cancelled() }}
         with:
-          # Name of the check run which will be created
           name: Mocha Tests
           path: mocha-report.json
           reporter: mocha-json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,10 +84,12 @@ jobs:
         with:
           filename: coverage/cobertura-coverage.xml
           badge: true
-          fail_below_min: false
+          fail_below_min: true
           format: markdown
           output: both
       - name: Display the report as a job summary
+        # Run this step even if the previous step failed
+        if: ${{ !cancelled() }}
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
 
   build-image:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
   run-reuse-workflow:
     uses: opalmedapps/.github/.github/workflows/reuse.yaml@main
 
-  test-mocha:
+  test-and-coverage:
     runs-on: ubuntu-latest
     steps:
       # Setup
@@ -47,11 +47,13 @@ jobs:
       - name: Print mocha version
         run: npx mocha --version
 
-      # Run tests
-      - name: Run mocha
-        run: npx mocha --reporter json --reporter-option output=mocha-report.json './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
+      # Run coverage evaluation
+      - name: Run nyc / cobertura
+        run: |
+          npx nyc --all --reporter cobertura mocha --reporter json --reporter-option output=mocha-report.json './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
+          npx nyc report
 
-      # Format the output for GitHub
+      # Format the test output for GitHub
       - name: Report test results
         uses: dorny/test-reporter@v2.1.0
         # Run this step even if the previous step failed
@@ -61,38 +63,24 @@ jobs:
           path: mocha-report.json
           reporter: mocha-json
 
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      # Setup
-      - uses: actions/checkout@v4.2.2
-        with:
-          persist-credentials: false
-      - name: Install dependencies
-        run: npm ci
-
-      # Run coverage evaluation
-      - name: Run nyc / cobertura
-        run: |
-          npx nyc --all --reporter cobertura mocha './src/**/*.test.*' './listener/**/*.test.*' './legacy-registration/**/*.test.*'
-          npx nyc report
-
-      # Format the output for GitHub
+      # Format the coverage output for GitHub
       - name: Report coverage results
         uses: irongut/CodeCoverageSummary@v1.3.0
+        # Run this step even if the previous step failed
+        if: ${{ !cancelled() }}
         with:
           filename: coverage/cobertura-coverage.xml
           badge: true
           fail_below_min: false
           format: markdown
           output: both
-      - name: Display the report as a job summary
+      - name: Add the coverage report to the job summary
         # Run this step even if the previous step failed
         if: ${{ !cancelled() }}
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
 
   build-image:
-    needs: [lint, test-mocha]
+    needs: [lint, test-and-coverage]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+      # TODO testing
+      - SB.ci-cd-mocha
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      # TODO testing
-      - SB.ci-cd-mocha
   pull_request:
   workflow_dispatch:
   merge_group:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Listener
 
-[![pipeline status](https://gitlab.com/opalmedapps/opal-listener/badges/main/pipeline.svg)](https://gitlab.com/opalmedapps/opal-listener/-/commits/main) [![coverage report](https://gitlab.com/opalmedapps/opal-listener/badges/main/coverage.svg)](https://gitlab.com/opalmedapps/opal-listener/-/commits/main) [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://opalmedapps.gitlab.io/opal-listener)
+[![pipeline status](https://gitlab.com/opalmedapps/opal-listener/badges/main/pipeline.svg)](https://gitlab.com/opalmedapps/opal-listener/-/commits/main)
+[![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](https://opalmedapps.gitlab.io/opal-listener)
 
 This is Opal's backend listener that facilitates communication between the user applications and the Opal PIE (typically running within a hospital network that cannot be accessed from the outside) via Firebase.
 

--- a/src/utility/version.test.js
+++ b/src/utility/version.test.js
@@ -29,7 +29,7 @@ describe('Version', function () {
             );
         });
         it('should return -1 when v1 < v2 (small difference)', function () {
-            expect(Version.compareVersions('0.2.0', '0.2.1')).to.equal(-1);
+            expect(Version.compareVersions('0.2.0', '0.2.1')).to.equal(0);
         });
         it('should return -1 when v1 < v2 (big difference)', function () {
             expect(Version.compareVersions('2.9.1', '4.0.1')).to.equal(-1);

--- a/src/utility/version.test.js
+++ b/src/utility/version.test.js
@@ -29,7 +29,7 @@ describe('Version', function () {
             );
         });
         it('should return -1 when v1 < v2 (small difference)', function () {
-            expect(Version.compareVersions('0.2.0', '0.2.1')).to.equal(0);
+            expect(Version.compareVersions('0.2.0', '0.2.1')).to.equal(-1);
         });
         it('should return -1 when v1 < v2 (big difference)', function () {
             expect(Version.compareVersions('2.9.1', '4.0.1')).to.equal(-1);


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)

### Changes
<!-- Summary of the changes in this MR. -->
Added a job to the CI workflow to run `mocha` unit tests, and to calculate code coverage. Both parts of this job display a report on the workflow page. Coverage is currently allowed to fail, until we raise it to a higher percentage.

### Dependencies
<!-- Link to dependent pull requests. Specify whether the MRs are just related, or require each other to run. Write N/A if there are none. -->
- **App**: N/A