### PR TITLE
build: copy node_modules to the working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG NODE_ENV="production"
 ENV NODE_ENV="${NODE_ENV}"
 
 COPY --from=dependencies /app/node_modules ./node_modules
-COPY ./package.json ./
+COPY ./package*.json ./
 
 # Copy all code sources
 COPY ./listener ./listener


### PR DESCRIPTION
I noticed that the dependencies are not "installed" correctly when running `npx firebase` in the container.

Running `npm list` gives the following output:

```console
/app $ npm list
opal-listener@1.0.0 /app
+-- UNMET DEPENDENCY @stablelib/base64@2.0.1
+-- UNMET DEPENDENCY @stablelib/utf8@2.0.1
+-- UNMET DEPENDENCY axios@1.13.2
+-- UNMET DEPENDENCY cross-env@10.1.0
+-- UNMET DEPENDENCY crypto-js@4.2.0
+-- UNMET DEPENDENCY dotenv@17.2.3
+-- UNMET DEPENDENCY express-validator@7.3.0
+-- UNMET DEPENDENCY firebase-admin@13.5.0
+-- UNMET DEPENDENCY html-to-text@9.0.5
+-- UNMET DEPENDENCY keyv@5.5.4
+-- UNMET DEPENDENCY moment@2.30.1
+-- UNMET DEPENDENCY mysql@2.18.1
+-- UNMET DEPENDENCY nodemailer@7.0.10
+-- UNMET DEPENDENCY nodemon@3.1.10
+-- UNMET DEPENDENCY q@1.5.1
+-- UNMET DEPENDENCY tweetnacl@1.0.3
`-- UNMET DEPENDENCY winston@3.18.3

npm error code ELSPROBLEMS
npm error missing: @stablelib/base64@2.0.1, required by opal-listener@1.0.0
npm error missing: @stablelib/utf8@2.0.1, required by opal-listener@1.0.0
npm error missing: axios@1.13.2, required by opal-listener@1.0.0
npm error missing: cross-env@10.1.0, required by opal-listener@1.0.0
npm error missing: crypto-js@4.2.0, required by opal-listener@1.0.0
npm error missing: dotenv@17.2.3, required by opal-listener@1.0.0
npm error missing: express-validator@7.3.0, required by opal-listener@1.0.0
npm error missing: firebase-admin@13.5.0, required by opal-listener@1.0.0
npm error missing: html-to-text@9.0.5, required by opal-listener@1.0.0
npm error missing: keyv@5.5.4, required by opal-listener@1.0.0
npm error missing: moment@2.30.1, required by opal-listener@1.0.0
npm error missing: mysql@2.18.1, required by opal-listener@1.0.0
npm error missing: nodemailer@7.0.10, required by opal-listener@1.0.0
npm error missing: nodemon@3.1.10, required by opal-listener@1.0.0
npm error missing: q@1.5.1, required by opal-listener@1.0.0
npm error missing: tweetnacl@1.0.3, required by opal-listener@1.0.0
npm error missing: winston@3.18.3, required by opal-listener@1.0.0
```

## Test Plan

Building an image with `NODE_ENV=production` and running `npm list` gives the following output:

```console
/app $ npm list
opal-listener@1.0.0 /app
+-- @stablelib/base64@2.0.1
+-- @stablelib/utf8@2.0.1
+-- axios@1.13.2
+-- cross-env@10.1.0
+-- crypto-js@4.2.0
+-- dotenv@17.2.3
+-- express-validator@7.3.0
+-- firebase-admin@13.5.0
+-- html-to-text@9.0.5
+-- keyv@5.5.4
+-- moment@2.30.1
+-- mysql@2.18.1
+-- nodemailer@7.0.10
+-- nodemon@3.1.10
+-- q@1.5.1
+-- tweetnacl@1.0.3
`-- winston@3.18.3
```

Also, `npx firebase` now works.