### PR TITLE
chore: improve Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,8 +10,8 @@
     ":pinAllExceptPeerDependencies",
     // https://docs.renovatebot.com/presets-default/#separatemultiplemajorreleases
     ":separateMultipleMajorReleases",
-    // https://docs.renovatebot.com/presets-default/#maintainlockfilesmonthly
-    ":maintainLockFilesMonthly",
+    // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
+    ":maintainLockFilesWeekly",
     // https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm
     "security:minimumReleaseAgeNpm",
     // set timezone to local one to ensure schedules are run


### PR DESCRIPTION
* group pre-commit hooks and schedule weekly
* maintain lock files weekly
* don't separate minor and patch updates to reduce amount of PRs
* add security npm preseet to require a minimum release age of 3 days