### PR TITLE
fix: reject correctly when a database query fails

### DIFF
--- a/listener/sql/sql-query-runner.js
+++ b/listener/sql/sql-query-runner.js
@@ -108,6 +108,7 @@ class SQLQueryRunner {
                     if (err) {
                         logger.log("error", `Failed to execute query: ${que.sql}`, err);
                         reject(err);
+                        return;
                     }
                     logger.log('info', `Successfully performed query: ${que.sql}`);
                     if (typeof rows !== 'undefined') {


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)

### Changes
<!-- Summary of the changes in this MR. -->
The `SQLQueryRunner` is set up to `reject` with an error when a query fails execution. However, because of the way code executes in a `return new Promise((resolve, reject)` block, execution doesn't terminate, and the listener continues with its success code (including printing `Successfully performed query`).

Added a `return` statement after `reject` to fix this issue.
