### PR TITLE
fix: fix variable preventing notifications from implicitly being marked as read

### DIFF
--- a/listener/api/sqlInterface.js
+++ b/listener/api/sqlInterface.js
@@ -284,7 +284,7 @@ function updateReadStatus(requestObject) {
                 logger.log('verbose', `Implicitly marking ${notificationType} notification as read.`);
                 await runSqlQuery(
                     queries.implicitlyReadNotification(),
-                    [userId, `"${userId}"`, parameters.Id, requestObject.TargetPatientID, notificationType],
+                    [requestObject.UserID, `"${requestObject.UserID}"`, parameters.Id, requestObject.TargetPatientID, notificationType],
                 );
             }
             r.resolve({Response:'success'});


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the [conventional commits convention](https://www.conventionalcommits.org/en/v1.0.0/#summary).

### Changes
<!-- Summary of the changes in this PR. -->
When the `sqlInterface` was refactored to ECMAScript module syntax, the function `updateReadStatus` was changed to take as input a `requestObject` instead of individual parameters. However, two references to the old parameter `userId` were left behind, breaking implicit reading of notifications.

Replaced references to this parameter with `requestObject.UserID` to fix the query execution.

### Dependencies
<!-- Link to dependent pull requests. Write N/A if there are none. To link to a PR in another repository, use syntax: opalmedapps/project-name#123 -->
- **Listener**: Bug introduced in #444

### Issues
<!-- Dynamic links to related issues (e.g. "Closes <issue>", "See <issue>"). -->
Closes opalmedapps/opal-app#1461
